### PR TITLE
Add model serialiser

### DIFF
--- a/blog/serializers.py
+++ b/blog/serializers.py
@@ -1,25 +1,9 @@
 from rest_framework import serializers
-from .models import Blog, BlogComment
+from .models import Blog
 
 
-class BlogSerializers(serializers.Serializer):
-    id = serializers.IntegerField(read_only=True)
-    name = serializers.CharField()
-    description= serializers.CharField()
-    post_date = serializers.DateField()
-    is_public = serializers.BooleanField()
-    slug = serializers.CharField(required=False)
-    
-    
-    def create(self, validated_data):
-        return Blog.objects.create(**validated_data)
-    
-    def update(self, instance, validated_data):
-        instance.name = validated_data.get('name', instance.name)
-        instance.description = validated_data.get('description', instance.description)
-        instance.post_date = validated_data.get('post_date', instance.post_date)
-        instance.is_public = validated_data.get('is_public', instance.is_public)
-        instance.slug = validated_data.get('slug', instance.slug)
-        instance.save()
-        return instance
-        
+class BlogSerializers(serializers.ModelSerializer):
+    class Meta:
+        model = Blog
+        fields = ('name', 'description', 'is_public', 'post_date', 'slug')
+        read_only_fields = ('post_date', 'slug')


### PR DESCRIPTION
## What was implemented in this PR

Refactored my code to make it more concise using Model. serializers. This prevents unnecessary code such as the `create()` and `update()`

```
class BlogSerializers(serializers.ModelSerializer):
    class Meta:
        model = Blog
        fields = ('name', 'description', 'is_public', 'post_date', 'slug')
        read_only_fields = ('post_date', 'slug')
```
The above is the only changes I made to the API compared with my previous PR.