### PR TITLE
Add a nested serializer category on the blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# NESTED SERIALIZERS 
+In otrher to create a nested serialisers, we neeed to sserilizers.  

--- a/blog/serializers.py
+++ b/blog/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Blog
+from .models import Blog, Category
 
 
 class BlogSerializers(serializers.ModelSerializer):
@@ -41,3 +41,11 @@ class BlogSerializers(serializers.ModelSerializer):
             raise serializers.ValidationError("name and description can't be same")
         else:
             return data
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    category_name = serializers.CharField()
+    category = BlogSerializers(many=True, read_only=True)
+    class Meta:
+        model = Category
+        exclude = ("id",)

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     path('blog-list/', views.BlogListView.as_view(), name='blog-list'),
     path('blog_detail/<slug:slug>/', views.BlogDetailView.as_view() , name='blog_detail'),
+    path('category-list/', views.CategoryListView.as_view() , name='category-list'),
+    path('category-detail/<int:pk>/', views.CategoryDetailView.as_view() , name='category-detail'),
 ]

--- a/blog/views.py
+++ b/blog/views.py
@@ -3,58 +3,58 @@ from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
 from rest_framework.decorators import api_view
 from rest_framework import status
-from blog.models import Blog
-from blog.serializers import BlogSerializers
+from blog.models import Blog, Category
+from blog.serializers import BlogSerializers, CategorySerializer
+
+
+class CategoryListView(APIView):
+    def get(self, request):
+        categories = Category.objects.all()
+        serializer = CategorySerializer(categories, many=True)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+
+class CategoryDetailView(APIView):
+    def get(self, request, pk):
+        category_detail = get_object_or_404(Category, pk=pk)
+        serializer = CategorySerializer(category_detail)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
 class BlogListView(APIView):
     def get(self, request):
         blogs = Blog.objects.all()
         serializer = BlogSerializers(blogs, many=True)
-        response = {
-            "message": "all blogs",
-            "data": serializer.data
-        }
+        response = {"message": "all blogs", "data": serializer.data}
         return Response(data=response, status=status.HTTP_200_OK)
-    
+
     def post(self, request):
         serializer = BlogSerializers(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            response = {
-                "message": "blog created",
-                "data": serializer.data
-            }
+            response = {"message": "blog created", "data": serializer.data}
             return Response(data=response, status=status.HTTP_201_CREATED)
         return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
+
 class BlogDetailView(APIView):
     def get(self, request, slug):
         blog = get_object_or_404(Blog, slug=slug)
         serializer = BlogSerializers(blog)
-        response = {
-            "message": "blog details",
-            "data": serializer.data
-        }
+        response = {"message": "blog details", "data": serializer.data}
         return Response(data=response, status=status.HTTP_200_OK)
-    
+
     def put(self, request, slug):
         blog = get_object_or_404(Blog, slug=slug)
         serializer = BlogSerializers(blog, data=request.data)
         if serializer.is_valid():
             serializer.save()
-            response = {
-                "message": "blog updated",
-                "data": serializer.data
-            }
+            response = {"message": "blog updated", "data": serializer.data}
             return Response(data=response, status=status.HTTP_200_OK)
         return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
     def delete(self, request, slug):
         blog = get_object_or_404(Blog, slug=slug)
         blog.delete()
-        response = {
-            "message": "blog deleted",
-            "data": {}
-        }
+        response = {"message": "blog deleted", "data": {}}
         return Response(data=response, status=status.HTTP_200_OK)


### PR DESCRIPTION
## What was implemented in this PR:

1. I added a nested serialiser `blog' in the CategorySerializer. What this mean is that for every blog post, you can see the category the post is related to.  The code that did all that magic is below:

```
class CategorySerializer(serializers.ModelSerializer):
    category_name = serializers.CharField()
    category = BlogSerializers(many=True, read_only=True)
    class Meta:
        model = Category
        exclude = ("id",)
```
2. I added categoryListView and CategoryDetailView to view the list of categories and the detail of each category. 
3. I also created endpoints for all features listed above.